### PR TITLE
Add Platform to Manifest

### DIFF
--- a/ootrando_overworldmap_hamsda/manifest.json
+++ b/ootrando_overworldmap_hamsda/manifest.json
@@ -3,6 +3,7 @@
   "game_name": "Ocarina of Time Randomizer",
   "package_version": "3.7.3.0",
   "package_uid": "ootrando_overworldmap_hamsda",
+  "platform": "n64",
   "author": "Hamsda",
   "variants": {
     "standard": {


### PR DESCRIPTION
Having this metadata in there is nice for completeness since there are many platforms supported by different emulators for autotracking and sorting.
